### PR TITLE
subscribe and cancel stream when widget tree change

### DIFF
--- a/lib/src/store_connector.dart
+++ b/lib/src/store_connector.dart
@@ -55,6 +55,16 @@ class StoreConnectorState<
     return _reduxProvider.store;
   }
 
+
+  @override
+  @mustCallSuper
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (widget._storeSub == null) {
+      _subscribe();
+    }
+  }
+
   @override
   @mustCallSuper
   void didUpdateWidget(StoreConnector oldWidget) {
@@ -67,9 +77,9 @@ class StoreConnectorState<
   /// Cancel the store subscription.
   @override
   @mustCallSuper
-  void dispose() {
+  void deactivate() {
     _unsubscribe();
-    super.dispose();
+    super.deactivate();
   }
 
   @override

--- a/lib/src/store_connector.dart
+++ b/lib/src/store_connector.dart
@@ -60,13 +60,6 @@ class StoreConnectorState<
     _subscribe();
   }
 
-  @override
-  @mustCallSuper
-  void didUpdateWidget(StoreConnector oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    _subscribe();
-  }
-
   /// Cancel the store subscription.
   @override
   @mustCallSuper

--- a/lib/src/store_connector.dart
+++ b/lib/src/store_connector.dart
@@ -15,8 +15,6 @@ abstract class StoreConnector<
     LocalState> extends StatefulWidget {
   StoreConnector({Key key}) : super(key: key);
 
-  StreamSubscription<SubstateChange<LocalState>> _storeSub;
-
   /// [connect] takes the current state of the redux store and retuns an object that contains
   /// the subset of the redux state tree that this component cares about.
   @protected
@@ -40,6 +38,8 @@ class StoreConnectorState<
         StoreConnector<StoreState, StoreStateBuilder, Actions, LocalState>> {
   ReduxProvider _reduxProvider;
 
+  StreamSubscription<SubstateChange<LocalState>> _storeSub;
+
   /// [LocalState] is an object that contains the subset of the redux state tree that this component
   /// cares about.
   LocalState _state;
@@ -60,18 +60,14 @@ class StoreConnectorState<
   @mustCallSuper
   void didChangeDependencies() {
     super.didChangeDependencies();
-    if (widget._storeSub == null) {
-      _subscribe();
-    }
+    _subscribe();
   }
 
   @override
   @mustCallSuper
   void didUpdateWidget(StoreConnector oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget._storeSub == null || oldWidget._storeSub != widget._storeSub) {
-      _subscribe();
-    }
+    _subscribe();
   }
 
   /// Cancel the store subscription.
@@ -93,7 +89,7 @@ class StoreConnectorState<
 
     _unsubscribe();
     // listen to changes
-    widget._storeSub = _store.substateStream(widget.connect).listen((change) {
+    _storeSub = _store.substateStream(widget.connect).listen((change) {
       setState(() {
         _state = change.next;
       });
@@ -101,8 +97,8 @@ class StoreConnectorState<
   }
 
   void _unsubscribe() {
-    widget._storeSub?.cancel();
-    widget._storeSub = null;
+    _storeSub?.cancel();
+    _storeSub = null;
   }
 }
 

--- a/lib/src/store_connector.dart
+++ b/lib/src/store_connector.dart
@@ -36,7 +36,6 @@ class StoreConnectorState<
         LocalState>
     extends State<
         StoreConnector<StoreState, StoreStateBuilder, Actions, LocalState>> {
-  ReduxProvider _reduxProvider;
 
   StreamSubscription<SubstateChange<LocalState>> _storeSub;
 
@@ -46,13 +45,11 @@ class StoreConnectorState<
 
   Store<StoreState, StoreStateBuilder, Actions> get _store {
     // get the store from the ReduxProvider ancestor
-    if (_reduxProvider == null) {
-      _reduxProvider = context.inheritFromWidgetOfExactType(ReduxProvider);
-      if (_reduxProvider == null)
+    ReduxProvider reduxProvider = context.inheritFromWidgetOfExactType(ReduxProvider);
+      if (reduxProvider == null)
         throw new Exception(
             "Store was not found, make sure ReduxProvider is an ancestor of this component");
-    }
-    return _reduxProvider.store;
+    return reduxProvider.store;
   }
 
 

--- a/lib/src/store_connector.dart
+++ b/lib/src/store_connector.dart
@@ -55,20 +55,11 @@ class StoreConnectorState<
     return _reduxProvider.store;
   }
 
-  /// setup a subscription to the store
-  @override
-  @mustCallSuper
-  void initState() {
-    super.initState();
-
-    _subscribe();
-  }
-
   @override
   @mustCallSuper
   void didUpdateWidget(StoreConnector oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget._storeSub != widget._storeSub) {
+    if (widget._storeSub == null || oldWidget._storeSub != widget._storeSub) {
       _subscribe();
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 # Important: Use "flutter packages get", not "pub get".
 name: flutter_built_redux
 author: David Marne <davemarne@gmail.com>
-version: 0.3.0
+version: 0.3.1
 description: Built_redux provider for Flutter
 homepage: https://github.com/davidmarne/flutter_built_redux
 dependencies:


### PR DESCRIPTION
This changes seem to fix issue #9 by canceling subscription on Widget `deactivated`. Widget is resubscribe both on `didChangeDependencies` and `didUpdateWidget`. 