### PR TITLE
Moved dependencies to build_value 5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,14 +6,14 @@ description: Built_redux provider for Flutter
 homepage: https://github.com/davidmarne/flutter_built_redux
 dependencies:
   built_redux: ">=6.1.1 <8.0.0"
-  built_value: ^4.0.0
+  built_value: ^5.0.0
   flutter:
     sdk: flutter
   meta: ^1.0.3
 
 dev_dependencies:
   build_runner: ^0.6.0
-  built_value_generator: ^4.1.0
+  built_value_generator: ^5.0.0
   flutter_test:
     sdk: flutter
   source_gen: ^0.7.0

--- a/test/unit/test_models.g.dart
+++ b/test/unit/test_models.g.dart
@@ -24,8 +24,8 @@ class _$Counter extends Counter {
       (new CounterBuilder()..update(updates)).build();
 
   _$Counter._({this.count, this.other}) : super._() {
-    if (count == null) throw new ArgumentError.notNull('count');
-    if (other == null) throw new ArgumentError.notNull('other');
+    if (count == null) throw new BuiltValueNullFieldError('Counter', 'count');
+    if (other == null) throw new BuiltValueNullFieldError('Counter', 'other');
   }
 
   @override


### PR DESCRIPTION
Due to some changes in dart version in flutter developers needs to increase also build_value version to 5. 

It also fixes this: https://github.com/davidmarne/flutter_built_redux/issues/15

