### PR TITLE
bump to 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+* Move built_value dependency to dev_dependencies and bump to ^5.0.0
+
 ## 0.4.2
 
 * Use assert for type assertions rather than thowing exceptions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,18 @@
 # Important: Use "flutter packages get", not "pub get".
 name: flutter_built_redux
 author: David Marne <davemarne@gmail.com>
-version: 0.4.2
+version: 0.4.3
 description: Built_redux provider for Flutter
 homepage: https://github.com/davidmarne/flutter_built_redux
 dependencies:
   built_redux: ">=6.1.1 <8.0.0"
-  built_value: ^5.0.0
   flutter:
     sdk: flutter
   meta: ^1.0.3
 
 dev_dependencies:
-  build_runner: ^0.6.0
+  build_runner: ^0.6.0  
+  built_value: ^5.0.0
   built_value_generator: ^5.0.0
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
bump to 0.4.3
move built_value to dev_dependencies since the library does not directly import it