### PR TITLE
0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.5
+
+* create explicit typedefs for funcs passed to StoreConnection, as the new Function syntax messes up the analyzer
+
 ## 0.4.4
 
 * add StoreConnection, which is an implementation of store connector that takes a connect & builder function as parameters.

--- a/lib/flutter_built_redux.dart
+++ b/lib/flutter_built_redux.dart
@@ -4,6 +4,14 @@ import 'package:meta/meta.dart';
 import 'package:flutter/widgets.dart' hide Builder;
 import 'package:built_redux/built_redux.dart';
 
+/// [Connect] maps state from the store to the local state that a give
+/// component cares about
+typedef LocalState Connect<StoreState, LocalState>(StoreState state);
+
+/// [WidgetBuilder] returns a widget given context, local state, and actions
+typedef Widget WidgetBuilder<LocalState, Actions extends ReduxActions>(
+    BuildContext context, LocalState state, Actions actions);
+
 /// [StoreConnection] is a widget that rebuilds when the redux store
 /// has triggered and the connect function yields a new result. It is an implementation
 /// of `StoreConnector` that takes a connect function and builder function as parameters
@@ -24,9 +32,8 @@ import 'package:built_redux/built_redux.dart';
 /// [LocalState] should be comparable. It is recommended to only use primitive or built types.
 class StoreConnection<StoreState, Actions extends ReduxActions, LocalState>
     extends StoreConnector<StoreState, Actions, LocalState> {
-  final LocalState Function(StoreState state) _connect;
-  final Widget Function(BuildContext context, LocalState state, Actions actions)
-      _builder;
+  final Connect<StoreState, LocalState> _connect;
+  final WidgetBuilder<LocalState, Actions> _builder;
 
   StoreConnection({
     @required LocalState connect(StoreState state),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 # Important: Use "flutter packages get", not "pub get".
 name: flutter_built_redux
 author: David Marne <davemarne@gmail.com>
-version: 0.4.4
+version: 0.4.5
 description: Built_redux provider for Flutter
 homepage: https://github.com/davidmarne/flutter_built_redux
 dependencies:


### PR DESCRIPTION
create explicit typedefs for funcs passed to StoreConnection, as the new Function syntax messes up the analyzer