### PR TITLE
added init function to StoreConnector

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ class AppScreen extends StoreConnector<App, AppActions, App> {
 }
 ```
 
-### Notes
-I'm maintaing this repository for personal usage. It can be removed at any time.
+## Notes
+I'm maintaining this repository for personal use. When and if those changes are merged in the default repository, I will remove this repository. If you want to use it for production, I recommend you to fork it.

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ You can override the `init` function to bind listeners you may need.
 
 Example Code:
 ```dart
-/// Displays the App.
-class AppScreen extends StoreConnector<App, AppActions, App> {
+/// Note that you must add AppBuilder too.
+class AppScreen extends StoreConnector<App, AppBuilder, AppActions, App> {
   /// Connects the state we need in this screen.
   @override
   App connect(App state) => state;
 
   /// Initializes necessary listeners for this screen.
   @override
-  void init(BuildContext context, Store store) {
+  void init(BuildContext context, Store<App, AppBuilder, AppActions> store) {
     // You can use the store to bind listeners and context to interact with the widget.
     store.stream.listen((change) {});
   }

--- a/README.md
+++ b/README.md
@@ -1,36 +1,39 @@
-[![Pub](https://img.shields.io/pub/v/flutter_built_redux.svg)](https://pub.dartlang.org/packages/flutter_built_redux)
-[![codecov.io](http://codecov.io/github/davidmarne/flutter_built_redux/coverage.svg?branch=master)](http://codecov.io/github/davidmarne/flutter_built_redux?branch=master)
-
 # flutter_built_redux
 
-[built_redux] bindings for Flutter.
+## Original Code
+[davidmarne/flutter-built_redux](https://github.com/davidmarne/flutter_built_redux)
 
-By creating a Widget that extends StoreConnector you get automatic subscribing to your redux store, and you component will only call setState when the store triggers and the values you take from the store in connect change!
+## Modifications
 
-## Examples
+### StoreConnector and StoreConnections calls init
+You can override the `init` function to bind listeners you may need.
 
-[counter example](example/example.dart)
+Example Code:
+```dart
+/// Displays the App.
+class AppScreen extends StoreConnector<App, AppActions, App> {
+  /// Connects the state we need in this screen.
+  @override
+  App connect(App state) => state;
 
-[todo_mvc], written by [Brian Egan]
+  /// Initializes necessary listeners for this screen.
+  @override
+  void init(BuildContext context, Store store) {
+    // You can use the store to bind listeners and context to interact with the widget.
+    store.stream.listen((change) {});
+  }
 
-## Why you may need flutter_built_redux
+  /// Build this screen.
+  @override
+  Widget build(BuildContext context, App state, AppActions actions) {
+    return Scaffold(
+        body: Center(
+          child: Text('Hello World'),
+        ),
+    );
+  }
+}
+```
 
-For the same reason you would want to use redux with react.
-
-from the flutter tutorial:
-
-> In Flutter, change notifications flow “up” the widget hierarchy by way of callbacks, while current state flows “down” to the stateless widgets that do presentation.
-
-Following this pattern requires you to send any state or state mutator callbacks that are common between your widgets down from some common ancestor.
-
-With larger applications this is very tedious, leads to large widget constructors, and this pattern causes flutter to rerun the build function on all widgets between the ancestor that contains the state and the widget that actually cares about it. It also means your business logic and network requests live in your widget declarations.
-
-[built_redux] gives you a predicable state container that can live outside your widgets and perform logic in action middleware.
-
-flutter_built_redux lets a widget to subscribe to the pieces of the redux state tree that it cares about. It also lets lets widgets dispatch actions to mutate the redux state tree. This means widgets can access and mutate application state without the state and state mutator callbacks being passed down from its ancestors!
-
-[built_redux]: https://github.com/davidmarne/built_redux
-
-[todo_mvc]: https://gitlab.com/brianegan/flutter_architecture_samples/tree/master/example/built_redux
-
-[Brian Egan]: https://gitlab.com/brianegan
+### Notes
+I'm maintaing this repository for personal usage. It can be removed at any time.

--- a/example/example.dart
+++ b/example/example.dart
@@ -70,7 +70,8 @@ class ConnectorExample extends StatelessWidget {
 }
 
 /// [CounterWidget] impelments [StoreConnector] manually
-class CounterWidget extends StoreConnector<Counter, CounterActions, int> {
+class CounterWidget
+    extends StoreConnector<Counter, CounterBuilder, CounterActions, int> {
   CounterWidget();
 
   @override

--- a/ios/Flutter/Generated.xcconfig
+++ b/ios/Flutter/Generated.xcconfig
@@ -1,0 +1,8 @@
+// This is a generated file; do not edit or check into version control.
+FLUTTER_ROOT=C:\Users\ga655\Documents\flutter
+FLUTTER_APPLICATION_PATH=c:\Users\ga655\Code\flutter_built_redux
+FLUTTER_TARGET=lib/main.dart
+FLUTTER_BUILD_MODE=debug
+FLUTTER_BUILD_DIR=build
+SYMROOT=${SOURCE_ROOT}/../build\ios
+FLUTTER_FRAMEWORK_DIR=C:\Users\ga655\Documents\flutter\bin\cache\artifacts\engine\ios

--- a/lib/flutter_built_redux.dart
+++ b/lib/flutter_built_redux.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:flutter/widgets.dart' hide Builder;
 import 'package:built_redux/built_redux.dart';
+import 'package:built_value/built_value.dart';
 
 /// [Connect] maps state from the store to the local state that a give
 /// component cares about
@@ -30,8 +31,12 @@ typedef Widget StoreConnectionBuilder<LocalState, Actions extends ReduxActions>(
 /// [Actions] is the generic tyoe of your built_redux store's actions contiainer
 /// [LocalState] is the state from your store that this widget needs to render.
 /// [LocalState] should be comparable. It is recommended to only use primitive or built types.
-class StoreConnection<StoreState, Actions extends ReduxActions, LocalState>
-    extends StoreConnector<StoreState, Actions, LocalState> {
+class StoreConnection<
+        StoreState extends Built<StoreState, StoreStateBuilder>,
+        StoreStateBuilder extends Builder<StoreState, StoreStateBuilder>,
+        Actions extends ReduxActions,
+        LocalState>
+    extends StoreConnector<StoreState, StoreStateBuilder, Actions, LocalState> {
   final Connect<StoreState, LocalState> _connect;
   final StoreConnectionBuilder<LocalState, Actions> _builder;
   final Function(BuildContext context, Store store) _init;
@@ -42,8 +47,7 @@ class StoreConnection<StoreState, Actions extends ReduxActions, LocalState>
         Widget builder(BuildContext context, LocalState state, Actions actions),
     void init(BuildContext context, Store store),
     Key key,
-  })
-      : assert(connect != null, 'StoreConnection: connect must not be null'),
+  })  : assert(connect != null, 'StoreConnection: connect must not be null'),
         assert(builder != null, 'StoreConnection: builder must not be null'),
         _connect = connect,
         _builder = builder,
@@ -57,8 +61,11 @@ class StoreConnection<StoreState, Actions extends ReduxActions, LocalState>
   Widget build(BuildContext context, LocalState state, Actions actions) =>
       _builder(context, state, actions);
 
-  @protected
-  void init(BuildContext context, Store store) => _init(context, store);
+  @override
+  void init(BuildContext context,
+      Store<StoreState, StoreStateBuilder, Actions> store) {
+    _init(context, store);
+  }
 }
 
 /// [StoreConnector] is a widget that rebuilds when the redux store
@@ -67,7 +74,10 @@ class StoreConnection<StoreState, Actions extends ReduxActions, LocalState>
 /// [Actions] is the generic tyoe of your built_redux store's actions contiainer
 /// [LocalState] is the state from your store that this widget needs to render.
 /// [LocalState] should be comparable. It is recommended to only use primitive or built types.
-abstract class StoreConnector<StoreState, Actions extends ReduxActions,
+abstract class StoreConnector<
+    StoreState extends Built<StoreState, StoreStateBuilder>,
+    StoreStateBuilder extends Builder<StoreState, StoreStateBuilder>,
+    Actions extends ReduxActions,
     LocalState> extends StatefulWidget {
   StoreConnector({Key key}) : super(key: key);
 
@@ -80,25 +90,32 @@ abstract class StoreConnector<StoreState, Actions extends ReduxActions,
   LocalState connect(StoreState state);
 
   @override
-  _StoreConnectorState<StoreState, Actions, LocalState> createState() =>
-      new _StoreConnectorState<StoreState, Actions, LocalState>();
+  _StoreConnectorState<StoreState, StoreStateBuilder, Actions, LocalState>
+      createState() => new _StoreConnectorState<StoreState, StoreStateBuilder,
+          Actions, LocalState>();
 
   @protected
   Widget build(BuildContext context, LocalState state, Actions actions);
 
   @protected
-  void init(BuildContext context, Store store) {}
+  void init(BuildContext context,
+      Store<StoreState, StoreStateBuilder, Actions> store) {}
 }
 
-class _StoreConnectorState<StoreState, Actions extends ReduxActions, LocalState>
-    extends State<StoreConnector<StoreState, Actions, LocalState>> {
+class _StoreConnectorState<
+        StoreState extends Built<StoreState, StoreStateBuilder>,
+        StoreStateBuilder extends Builder<StoreState, StoreStateBuilder>,
+        Actions extends ReduxActions,
+        LocalState>
+    extends State<
+        StoreConnector<StoreState, StoreStateBuilder, Actions, LocalState>> {
   StreamSubscription<SubstateChange<LocalState>> _storeSub;
 
   /// [LocalState] is an object that contains the subset of the redux state tree that this component
   /// cares about.
   LocalState _state;
 
-  Store get _store {
+  Store<StoreState, StoreStateBuilder, Actions> get _store {
     // get the store from the ReduxProvider ancestor
     final ReduxProvider reduxProvider =
         context.inheritFromWidgetOfExactType(ReduxProvider);
@@ -113,7 +130,7 @@ class _StoreConnectorState<StoreState, Actions extends ReduxActions, LocalState>
     assert(reduxProvider.store.actions is Actions,
         'Store found was not the correct type, make sure StoreConnector\'s generic for Actions matches the actions type of your built_redux store.');
 
-    return reduxProvider.store;
+    return reduxProvider.store as Store<StoreState, StoreStateBuilder, Actions>;
   }
 
   /// sets up a subscription to the store

--- a/lib/flutter_built_redux.dart
+++ b/lib/flutter_built_redux.dart
@@ -34,17 +34,20 @@ class StoreConnection<StoreState, Actions extends ReduxActions, LocalState>
     extends StoreConnector<StoreState, Actions, LocalState> {
   final Connect<StoreState, LocalState> _connect;
   final StoreConnectionBuilder<LocalState, Actions> _builder;
+  final Function(BuildContext context, Store store) _init;
 
   StoreConnection({
     @required LocalState connect(StoreState state),
     @required
         Widget builder(BuildContext context, LocalState state, Actions actions),
+    void init(BuildContext context, Store store),
     Key key,
   })
       : assert(connect != null, 'StoreConnection: connect must not be null'),
         assert(builder != null, 'StoreConnection: builder must not be null'),
         _connect = connect,
         _builder = builder,
+        _init = init,
         super(key: key);
 
   @protected
@@ -53,6 +56,9 @@ class StoreConnection<StoreState, Actions extends ReduxActions, LocalState>
   @protected
   Widget build(BuildContext context, LocalState state, Actions actions) =>
       _builder(context, state, actions);
+
+  @protected
+  void init(BuildContext context, Store store) => _init(context, store);
 }
 
 /// [StoreConnector] is a widget that rebuilds when the redux store
@@ -79,6 +85,9 @@ abstract class StoreConnector<StoreState, Actions extends ReduxActions,
 
   @protected
   Widget build(BuildContext context, LocalState state, Actions actions);
+
+  @protected
+  void init(BuildContext context, Store store) {}
 }
 
 class _StoreConnectorState<StoreState, Actions extends ReduxActions, LocalState>
@@ -123,6 +132,9 @@ class _StoreConnectorState<StoreState, Actions extends ReduxActions, LocalState>
 
     // set the initial state
     _state = widget.connect(_store.state as StoreState);
+
+    // calls init so the user can bind his listeners
+    widget.init(context, _store);
 
     // listen to changes
     _storeSub = _store

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,14 +5,16 @@ version: 0.5.0
 description: Built_redux provider for Flutter
 homepage: https://github.com/davidmarne/flutter_built_redux
 dependencies:
+  # built_redux:
+  #   git: https://github.com/ga6559/built_redux
   built_redux:
-    git: https://github.com/ga6559/built_redux
+    path: ../built_redux
   flutter:
     sdk: flutter
   meta: ^1.0.3
 
 dev_dependencies:
-  build_runner: ^0.6.0  
+  build_runner: ^0.8.0
   built_value: ^5.0.0
   built_value_generator: ^5.0.0
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,8 @@ version: 0.5.0
 description: Built_redux provider for Flutter
 homepage: https://github.com/davidmarne/flutter_built_redux
 dependencies:
-  built_redux: ">=6.1.1 <8.0.0"
+  built_redux:
+    git: https://github.com/ga6559/built_redux
   flutter:
     sdk: flutter
   meta: ^1.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,10 +5,8 @@ version: 0.5.0
 description: Built_redux provider for Flutter
 homepage: https://github.com/davidmarne/flutter_built_redux
 dependencies:
-  # built_redux:
-  #   git: https://github.com/ga6559/built_redux
   built_redux:
-    path: ../built_redux
+    git: https://github.com/ga6559/built_redux
   flutter:
     sdk: flutter
   meta: ^1.0.3


### PR DESCRIPTION
Make binding store listeners in widgets easier. #25 

We can use it like that:

```dart
class AppScreen extends StoreConnector<App, AppActions, App> {
  @override
  Counter connect(App state) => state;

  @override
  void init(BuildContext context, Store store) {
    store
        .actionStream(AppActionsNames.dataCorrupted)
        .listen((change) {
      Scaffold
          .of(context)
          .showSnackBar(SnackBar(content: Text('Data Corrupted')));
    });
  }

  @override
  Widget build(BuildContext context, Counter state, AppActions actions) {
    return Scaffold(
      appBar: AppBar(
        title: Text('My App'),
      ),
      body: Text('Hello World')
   );
  }
}
```