### PR TITLE
Migrate to dart 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .pub
 packages
 pubspec.lock
+.dart_tool/
 
 # flutter
 build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0
+* Migrate to Dart 2
+* Bump dependencies to more recent versions
+
 ## 0.5.0
 
 * **Breaking changes**:

--- a/example/example.g.dart
+++ b/example/example.g.dart
@@ -3,16 +3,45 @@
 part of example;
 
 // **************************************************************************
-// Generator: BuiltValueGenerator
+// BuiltReduxGenerator
+// **************************************************************************
+
+// ignore_for_file: avoid_classes_with_only_static_members
+// ignore_for_file: annotate_overrides
+
+class _$CounterActions extends CounterActions {
+  factory _$CounterActions() => new _$CounterActions._();
+  _$CounterActions._() : super._();
+
+  final ActionDispatcher<Null> increment =
+      new ActionDispatcher<Null>('CounterActions-increment');
+
+  @override
+  void setDispatcher(Dispatcher dispatcher) {
+    increment.setDispatcher(dispatcher);
+  }
+}
+
+class CounterActionsNames {
+  static final ActionName<Null> increment =
+      new ActionName<Null>('CounterActions-increment');
+}
+
+// **************************************************************************
+// BuiltValueGenerator
 // **************************************************************************
 
 // ignore_for_file: always_put_control_body_on_new_line
 // ignore_for_file: annotate_overrides
 // ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
 // ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: omit_local_variable_types
 // ignore_for_file: prefer_expression_function_bodies
 // ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
 
 class _$Counter extends Counter {
   @override
@@ -33,10 +62,9 @@ class _$Counter extends Counter {
   CounterBuilder toBuilder() => new CounterBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! Counter) return false;
-    return count == other.count;
+    return other is Counter && count == other.count;
   }
 
   @override
@@ -85,26 +113,4 @@ class CounterBuilder implements Builder<Counter, CounterBuilder> {
     replace(_$result);
     return _$result;
   }
-}
-
-// **************************************************************************
-// Generator: BuiltReduxGenerator
-// **************************************************************************
-
-class _$CounterActions extends CounterActions {
-  factory _$CounterActions() => new _$CounterActions._();
-  _$CounterActions._() : super._();
-
-  final ActionDispatcher<Null> increment =
-      new ActionDispatcher<Null>('CounterActions-increment');
-
-  @override
-  void setDispatcher(Dispatcher dispatcher) {
-    increment.setDispatcher(dispatcher);
-  }
-}
-
-class CounterActionsNames {
-  static final ActionName<Null> increment =
-      new ActionName<Null>('CounterActions-increment');
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 # Important: Use "flutter packages get", not "pub get".
 name: flutter_built_redux
 author: David Marne <davemarne@gmail.com>
-version: 0.5.0
+version: 0.6.0
 description: Built_redux provider for Flutter
 homepage: https://github.com/davidmarne/flutter_built_redux
 dependencies:
@@ -11,12 +11,12 @@ dependencies:
   meta: ^1.0.3
 
 dev_dependencies:
-  build_runner: ^0.6.0  
-  built_value: ^5.0.0
-  built_value_generator: ^5.0.0
+  build_runner: ">=0.6.0 <0.11.0"
+  built_value: ">=5.0.0 <7.0.0"
+  built_value_generator: ">=5.0.0 <7.0.0"
   flutter_test:
     sdk: flutter
-  source_gen: ^0.7.0
+  #source_gen: ^0.7.0
 
 environment:
-  sdk: ">=1.19.0 <2.0.0"
+  sdk: ">=2.0.0 <3.0.0"

--- a/test/unit/test_models.g.dart
+++ b/test/unit/test_models.g.dart
@@ -3,16 +3,50 @@
 part of test_models;
 
 // **************************************************************************
-// Generator: BuiltValueGenerator
+// BuiltReduxGenerator
+// **************************************************************************
+
+// ignore_for_file: avoid_classes_with_only_static_members
+// ignore_for_file: annotate_overrides
+
+class _$CounterActions extends CounterActions {
+  factory _$CounterActions() => new _$CounterActions._();
+  _$CounterActions._() : super._();
+
+  final ActionDispatcher<Null> increment =
+      new ActionDispatcher<Null>('CounterActions-increment');
+  final ActionDispatcher<Null> incrementOther =
+      new ActionDispatcher<Null>('CounterActions-incrementOther');
+
+  @override
+  void setDispatcher(Dispatcher dispatcher) {
+    increment.setDispatcher(dispatcher);
+    incrementOther.setDispatcher(dispatcher);
+  }
+}
+
+class CounterActionsNames {
+  static final ActionName<Null> increment =
+      new ActionName<Null>('CounterActions-increment');
+  static final ActionName<Null> incrementOther =
+      new ActionName<Null>('CounterActions-incrementOther');
+}
+
+// **************************************************************************
+// BuiltValueGenerator
 // **************************************************************************
 
 // ignore_for_file: always_put_control_body_on_new_line
 // ignore_for_file: annotate_overrides
 // ignore_for_file: avoid_annotating_with_dynamic
+// ignore_for_file: avoid_catches_without_on_clauses
 // ignore_for_file: avoid_returning_this
+// ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: omit_local_variable_types
 // ignore_for_file: prefer_expression_function_bodies
 // ignore_for_file: sort_constructors_first
+// ignore_for_file: unnecessary_const
+// ignore_for_file: unnecessary_new
 
 class _$Counter extends Counter {
   @override
@@ -36,10 +70,9 @@ class _$Counter extends Counter {
   CounterBuilder toBuilder() => new CounterBuilder()..replace(this);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    if (other is! Counter) return false;
-    return count == other.count && other == other.other;
+    return other is Counter && count == other.count && other == other.other;
   }
 
   @override
@@ -95,31 +128,4 @@ class CounterBuilder implements Builder<Counter, CounterBuilder> {
     replace(_$result);
     return _$result;
   }
-}
-
-// **************************************************************************
-// Generator: BuiltReduxGenerator
-// **************************************************************************
-
-class _$CounterActions extends CounterActions {
-  factory _$CounterActions() => new _$CounterActions._();
-  _$CounterActions._() : super._();
-
-  final ActionDispatcher<Null> increment =
-      new ActionDispatcher<Null>('CounterActions-increment');
-  final ActionDispatcher<Null> incrementOther =
-      new ActionDispatcher<Null>('CounterActions-incrementOther');
-
-  @override
-  void setDispatcher(Dispatcher dispatcher) {
-    increment.setDispatcher(dispatcher);
-    incrementOther.setDispatcher(dispatcher);
-  }
-}
-
-class CounterActionsNames {
-  static final ActionName<Null> increment =
-      new ActionName<Null>('CounterActions-increment');
-  static final ActionName<Null> incrementOther =
-      new ActionName<Null>('CounterActions-incrementOther');
 }


### PR DESCRIPTION
Move flutter_built_redux to support Dart 2 and a wider version of the built* generators.

This change removes support for Dart 1.

* Tests pass
* My app using flutter_built_redux functions fine with these changes

PTAL @davidmarne 