### PR TITLE
when changes state and widget, but state reuse, the new ui won't update.

### DIFF
--- a/lib/flutter_built_redux.dart
+++ b/lib/flutter_built_redux.dart
@@ -145,6 +145,18 @@ class _StoreConnectorState<StoreState, Actions extends ReduxActions, LocalState>
   @override
   Widget build(BuildContext context) =>
       widget.build(context, _state, _store.actions as Actions);
+
+  @mustCallSuper
+  @protected
+  void didUpdateWidget(StoreConnector oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final newState = widget.connect(_store.state as StoreState);
+    if (_state != newState) {
+      setState(() {
+        _state = newState;
+      });
+    }
+  }
 }
 
 /// [ReduxProvider] provides access to the redux store to descendant widgets.


### PR DESCRIPTION
e.
UserInfo extends StoreConnector<....>{
  final String userId;
  UserInfo(this.userId);
  connect(){...}
  build(){....}
}

when refresh list of UserInfo, ui won't update.  we should override the didUpdateWidget, force run the connect function, and setState