### PR TITLE
upgrade: Flutter 2

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,3 +2,5 @@ analyzer:
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false
+  exclude:
+    - "**/*.g.dart"

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,23 +1,23 @@
 library example;
 
 import 'package:built_redux/built_redux.dart';
-import 'package:flutter_built_redux/flutter_built_redux.dart';
-import 'package:flutter/material.dart' hide Builder;
 import 'package:built_value/built_value.dart';
+import 'package:flutter/material.dart' hide Builder, ActionDispatcher;
+import 'package:flutter_built_redux/flutter_built_redux.dart';
 
 part 'example.g.dart';
 
 void main() {
   // create the store
-  final store = new Store(
+  final store = Store(
     reducerBuilder.build(),
-    new Counter(),
-    new CounterActions(),
+    Counter(),
+    CounterActions(),
   );
 
-  runApp(new ConnectionExample(store));
+  runApp(ConnectionExample(store));
   // or comment the line above and uncomment the line below
-  // runApp(new ConnectorExample(store));
+  // runApp(ConnectorExample(store));
 }
 
 /// an example using `StoreConnection`
@@ -27,21 +27,21 @@ class ConnectionExample extends StatelessWidget {
   ConnectionExample(this.store);
 
   @override
-  Widget build(BuildContext context) => new MaterialApp(
+  Widget build(BuildContext context) => MaterialApp(
         title: 'flutter_built_redux_test',
-        home: new ReduxProvider(
+        home: ReduxProvider(
           store: store,
-          child: new StoreConnection<Counter, CounterActions, int>(
+          child: StoreConnection<Counter, CounterActions, int>(
             connect: (state) => state.count,
             builder: (BuildContext context, int count, CounterActions actions) {
-              return new Scaffold(
-                body: new Row(
+              return Scaffold(
+                body: Row(
                   children: <Widget>[
-                    new RaisedButton(
-                      onPressed: actions.increment,
-                      child: new Text('Increment'),
+                    ElevatedButton(
+                      onPressed: () => actions.increment(null),
+                      child: Text('Increment'),
                     ),
-                    new Text('Count: $count'),
+                    Text('Count: $count'),
                   ],
                 ),
               );
@@ -59,11 +59,11 @@ class ConnectorExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return new MaterialApp(
+    return MaterialApp(
       title: 'flutter_built_redux_test',
-      home: new ReduxProvider(
+      home: ReduxProvider(
         store: store,
-        child: new CounterWidget(),
+        child: CounterWidget(),
       ),
     );
   }
@@ -78,14 +78,14 @@ class CounterWidget extends StoreConnector<Counter, CounterActions, int> {
 
   @override
   Widget build(BuildContext context, int count, CounterActions actions) =>
-      new Scaffold(
-        body: new Row(
+      Scaffold(
+        body: Row(
           children: <Widget>[
-            new RaisedButton(
-              onPressed: actions.increment,
-              child: new Text('Increment'),
+            ElevatedButton(
+              onPressed: () => actions.increment(null),
+              child: Text('Increment'),
             ),
-            new Text('Count: $count'),
+            Text('Count: $count'),
           ],
         ),
       );
@@ -94,18 +94,18 @@ class CounterWidget extends StoreConnector<Counter, CounterActions, int> {
 // Built redux counter state, actions, and reducer
 
 ReducerBuilder<Counter, CounterBuilder> reducerBuilder =
-    new ReducerBuilder<Counter, CounterBuilder>()
+    ReducerBuilder<Counter, CounterBuilder>()
       ..add(CounterActionsNames.increment, (s, a, b) => b.count++);
 
 abstract class CounterActions extends ReduxActions {
-  factory CounterActions() => new _$CounterActions();
+  factory CounterActions() => _$CounterActions();
   CounterActions._();
 
   ActionDispatcher<Null> get increment;
 }
 
 abstract class Counter implements Built<Counter, CounterBuilder> {
-  factory Counter() => new _$Counter._(count: 0);
+  factory Counter() => _$Counter._(count: 0);
   Counter._();
 
   int get count;

--- a/lib/flutter_built_redux.dart
+++ b/lib/flutter_built_redux.dart
@@ -145,7 +145,7 @@ class _StoreConnectorState<StoreState, Actions extends ReduxActions, LocalState>
 }
 
 /// [ReduxProvider] provides access to the redux store to descendant widgets.
-/// [ReduxProvider] must be an ancesestor of a `StoreConnector`, otherwise the
+/// [ReduxProvider] must be an ancestor of a `StoreConnector`, otherwise the
 /// `StoreConnector` will throw during initialization.
 class ReduxProvider extends InheritedWidget {
   ReduxProvider({Key? key, required this.store, required Widget child})

--- a/lib/flutter_built_redux.dart
+++ b/lib/flutter_built_redux.dart
@@ -36,13 +36,11 @@ class StoreConnection<StoreState, Actions extends ReduxActions, LocalState>
   final StoreConnectionBuilder<LocalState, Actions> _builder;
 
   StoreConnection({
-    @required LocalState connect(StoreState state),
-    @required
-        Widget builder(BuildContext context, LocalState state, Actions actions),
-    Key key,
-  })  : assert(connect != null, 'StoreConnection: connect must not be null'),
-        assert(builder != null, 'StoreConnection: builder must not be null'),
-        _connect = connect,
+    required LocalState connect(StoreState state),
+    required Widget builder(
+        BuildContext context, LocalState state, Actions actions),
+    Key? key,
+  })  : _connect = connect,
         _builder = builder,
         super(key: key);
 
@@ -62,7 +60,7 @@ class StoreConnection<StoreState, Actions extends ReduxActions, LocalState>
 /// [LocalState] should be comparable. It is recommended to only use primitive or built types.
 abstract class StoreConnector<StoreState, Actions extends ReduxActions,
     LocalState> extends StatefulWidget {
-  StoreConnector({Key key}) : super(key: key);
+  StoreConnector({Key? key}) : super(key: key);
 
   /// [connect] takes the current state of the redux store and retuns an object that contains
   /// the subset of the redux state tree that this component cares about.
@@ -81,29 +79,29 @@ abstract class StoreConnector<StoreState, Actions extends ReduxActions,
 }
 
 class _StoreConnectorState<StoreState, Actions extends ReduxActions, LocalState>
-    extends State<StoreConnector<StoreState, Actions, LocalState>> {
-  StreamSubscription<SubstateChange<LocalState>> _storeSub;
+    extends State<StoreConnector<StoreState, Actions, LocalState?>> {
+  StreamSubscription<SubstateChange<LocalState?>>? _storeSub;
 
   /// [LocalState] is an object that contains the subset of the redux state tree that this component
   /// cares about.
-  LocalState _state;
+  LocalState? _state;
 
-  Store get _store {
+  Store? get _store {
     // get the store from the ReduxProvider ancestor
-    final ReduxProvider reduxProvider =
+    final ReduxProvider? reduxProvider =
         context.dependOnInheritedWidgetOfExactType<ReduxProvider>();
 
     // if it is not found raise an error
     assert(reduxProvider != null,
         'Store was not found, make sure ReduxProvider is an ancestor of this component.');
 
-    assert(reduxProvider.store.state is StoreState,
+    assert(reduxProvider?.store!.state is StoreState,
         'Store found was not the correct type, make sure StoreConnector\'s generic for StoreState matches the state type of your built_redux store.');
 
-    assert(reduxProvider.store.actions is Actions,
+    assert(reduxProvider?.store!.actions is Actions,
         'Store found was not the correct type, make sure StoreConnector\'s generic for Actions matches the actions type of your built_redux store.');
 
-    return reduxProvider.store;
+    return reduxProvider?.store;
   }
 
   /// sets up a subscription to the store
@@ -121,10 +119,10 @@ class _StoreConnectorState<StoreState, Actions extends ReduxActions, LocalState>
     if (_storeSub != null) return;
 
     // set the initial state
-    _state = widget.connect(_store.state as StoreState);
+    _state = widget.connect(_store!.state as StoreState);
 
     // listen to changes
-    _storeSub = _store
+    _storeSub = _store!
         .substateStream((state) => widget.connect(state as StoreState))
         .listen((change) {
       setState(() {
@@ -137,24 +135,24 @@ class _StoreConnectorState<StoreState, Actions extends ReduxActions, LocalState>
   @override
   @mustCallSuper
   void dispose() {
-    _storeSub.cancel();
+    _storeSub!.cancel();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) =>
-      widget.build(context, _state, _store.actions as Actions);
+      widget.build(context, _state, _store!.actions as Actions);
 }
 
 /// [ReduxProvider] provides access to the redux store to descendant widgets.
 /// [ReduxProvider] must be an ancesestor of a `StoreConnector`, otherwise the
 /// `StoreConnector` will throw during initialization.
 class ReduxProvider extends InheritedWidget {
-  ReduxProvider({Key key, @required this.store, @required Widget child})
+  ReduxProvider({Key? key, required this.store, required Widget child})
       : super(key: key, child: child);
 
   /// [store] is a reference to the redux store
-  final Store store;
+  final Store? store;
 
   @override
   bool updateShouldNotify(ReduxProvider old) => store != old.store;

--- a/lib/flutter_built_redux.dart
+++ b/lib/flutter_built_redux.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
-import 'package:meta/meta.dart';
-import 'package:flutter/widgets.dart' hide Builder;
 import 'package:built_redux/built_redux.dart';
+import 'package:flutter/widgets.dart' hide Builder;
+import 'package:meta/meta.dart';
 
 /// [Connect] maps state from the store to the local state that a give
 /// component cares about
@@ -40,8 +40,7 @@ class StoreConnection<StoreState, Actions extends ReduxActions, LocalState>
     @required
         Widget builder(BuildContext context, LocalState state, Actions actions),
     Key key,
-  })
-      : assert(connect != null, 'StoreConnection: connect must not be null'),
+  })  : assert(connect != null, 'StoreConnection: connect must not be null'),
         assert(builder != null, 'StoreConnection: builder must not be null'),
         _connect = connect,
         _builder = builder,
@@ -92,7 +91,7 @@ class _StoreConnectorState<StoreState, Actions extends ReduxActions, LocalState>
   Store get _store {
     // get the store from the ReduxProvider ancestor
     final ReduxProvider reduxProvider =
-        context.inheritFromWidgetOfExactType(ReduxProvider);
+        context.dependOnInheritedWidgetOfExactType<ReduxProvider>();
 
     // if it is not found raise an error
     assert(reduxProvider != null,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,18 +5,17 @@ version: 0.6.0
 description: Built_redux provider for Flutter
 homepage: https://github.com/davidmarne/flutter_built_redux
 dependencies:
-  built_redux: ">=6.1.1 <8.0.0"
+  built_redux: ^8.0.0-nullsafety.0
   flutter:
     sdk: flutter
-  meta: ^1.0.3
+  meta: ^1.3.0
 
 dev_dependencies:
-  build_runner: ">=0.6.0 <0.11.0"
-  built_value: ">=5.0.0 <7.0.0"
-  built_value_generator: ">=5.0.0 <7.0.0"
+  build_runner: ^1.10.0
+  built_value: ^8.0.0
+  built_value_generator: ^8.0.0
   flutter_test:
     sdk: flutter
-  #source_gen: ^0.7.0
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'

--- a/test/unit/flutter_built_redux_test.dart
+++ b/test/unit/flutter_built_redux_test.dart
@@ -6,21 +6,21 @@ import 'test_models.dart';
 import 'test_widget.dart';
 
 void main() {
-  Store<Counter, CounterBuilder, CounterActions> store;
+  Store<Counter, CounterBuilder, CounterActions>? store;
 
   setUp(() {
     store = createStore();
   });
 
   tearDown(() async {
-    await store.dispose();
+    await store!.dispose();
   });
 
   group('flutter_built_redux: ', () {
     group('StoreConnector: ', () {
       testWidgets('renders default state correctly',
           (WidgetTester tester) async {
-        final providerWidget = new ProviderWidgetConnector(store);
+        final providerWidget = ProviderWidgetConnector(store);
 
         await tester.pumpWidget(providerWidget);
 
@@ -37,7 +37,7 @@ void main() {
       });
 
       testWidgets('rerenders after increment', (WidgetTester tester) async {
-        final widget = new ProviderWidgetConnector(store);
+        final widget = ProviderWidgetConnector(store);
 
         await tester.pumpWidget(widget);
 
@@ -69,7 +69,7 @@ void main() {
 
       testWidgets('does not rerender after update to other counter',
           (WidgetTester tester) async {
-        final widget = new ProviderWidgetConnector(store);
+        final widget = ProviderWidgetConnector(store);
 
         await tester.pumpWidget(widget);
 
@@ -104,7 +104,7 @@ void main() {
     group('StoreConnection: ', () {
       testWidgets('renders default state correctly',
           (WidgetTester tester) async {
-        final providerWidget = new ProviderWidgetConnection(store);
+        final providerWidget = ProviderWidgetConnection(store);
 
         await tester.pumpWidget(providerWidget);
 
@@ -117,7 +117,7 @@ void main() {
       });
 
       testWidgets('rerenders after increment', (WidgetTester tester) async {
-        final providerWidget = new ProviderWidgetConnection(store);
+        final providerWidget = ProviderWidgetConnection(store);
 
         await tester.pumpWidget(providerWidget);
 
@@ -141,7 +141,7 @@ void main() {
 
       testWidgets('does not rerender after update to other counter',
           (WidgetTester tester) async {
-        final providerWidget = new ProviderWidgetConnection(store);
+        final providerWidget = ProviderWidgetConnection(store);
 
         await tester.pumpWidget(providerWidget);
 

--- a/test/unit/test_models.dart
+++ b/test/unit/test_models.dart
@@ -1,24 +1,24 @@
 library test_models;
 
-import 'package:built_value/built_value.dart';
 import 'package:built_redux/built_redux.dart';
+import 'package:built_value/built_value.dart';
 
 part 'test_models.g.dart';
 
-Store<Counter, CounterBuilder, CounterActions> createStore() => new Store(
+Store<Counter, CounterBuilder, CounterActions> createStore() => Store(
       createReducer(),
-      new Counter(),
-      new CounterActions(),
+      Counter(),
+      CounterActions(),
     );
 
 Reducer<Counter, CounterBuilder, dynamic> createReducer() =>
-    (new ReducerBuilder<Counter, CounterBuilder>()
+    (ReducerBuilder<Counter, CounterBuilder>()
           ..add(CounterActionsNames.increment, (s, a, b) => b.count++)
           ..add(CounterActionsNames.incrementOther, (s, a, b) => b.other++))
         .build();
 
 abstract class CounterActions extends ReduxActions {
-  factory CounterActions() => new _$CounterActions();
+  factory CounterActions() => _$CounterActions();
   CounterActions._();
 
   ActionDispatcher<Null> get increment;
@@ -26,12 +26,12 @@ abstract class CounterActions extends ReduxActions {
 }
 
 abstract class Counter implements Built<Counter, CounterBuilder> {
-  factory Counter() => new _$Counter._(
+  factory Counter() => _$Counter._(
         count: 0,
         other: 0,
       );
   Counter._();
 
-  int get count;
-  int get other;
+  int? get count;
+  int? get other;
 }

--- a/test/unit/test_widget.dart
+++ b/test/unit/test_widget.dart
@@ -1,61 +1,61 @@
 import 'package:built_redux/built_redux.dart';
-import 'package:flutter_built_redux/flutter_built_redux.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_built_redux/flutter_built_redux.dart';
 
 import 'test_models.dart';
 
-final providerKey = new Key('providerKey');
-final counterKey = new Key('counterKey');
-final incrementTextKey = new Key('incrementTextKey');
-final incrementButtonKey = new Key('incrementButtonKey');
-final incrementOtherButtonKey = new Key('incrementOtherButtonKey');
+final providerKey = Key('providerKey');
+final counterKey = Key('counterKey');
+final incrementTextKey = Key('incrementTextKey');
+final incrementButtonKey = Key('incrementButtonKey');
+final incrementOtherButtonKey = Key('incrementOtherButtonKey');
 
 class ProviderWidgetConnector extends StatelessWidget {
-  final Store<Counter, CounterBuilder, CounterActions> store;
+  final Store<Counter, CounterBuilder, CounterActions>? store;
 
   ProviderWidgetConnector(this.store) : super(key: providerKey);
 
   @override
-  Widget build(BuildContext context) => new MaterialApp(
+  Widget build(BuildContext context) => MaterialApp(
         title: 'flutter_built_redux_test',
-        home: new ReduxProvider(
+        home: ReduxProvider(
           store: store,
-          child: new CounterWidget(),
+          child: CounterWidget(),
         ),
       );
 }
 
 // ignore: must_be_immutable
 class ProviderWidgetConnection extends StatelessWidget {
-  final Store<Counter, CounterBuilder, CounterActions> store;
+  final Store<Counter, CounterBuilder, CounterActions>? store;
   int numBuilds = 0;
 
   ProviderWidgetConnection(this.store) : super(key: providerKey);
 
   @override
-  Widget build(BuildContext context) => new MaterialApp(
+  Widget build(BuildContext context) => MaterialApp(
         title: 'flutter_built_redux_test',
-        home: new ReduxProvider(
+        home: ReduxProvider(
           store: store,
-          child: new StoreConnection<Counter, CounterActions, int>(
+          child: StoreConnection<Counter, CounterActions, int?>(
             connect: (state) => state.count,
             key: counterKey,
-            builder: (BuildContext context, int count, CounterActions actions) {
+            builder: (BuildContext context, int? count, CounterActions actions) {
               numBuilds++;
-              return new Scaffold(
-                body: new Row(
+              return Scaffold(
+                body: Row(
                   children: <Widget>[
-                    new RaisedButton(
-                      onPressed: actions.increment,
-                      child: new Text('Increment'),
+                    ElevatedButton(
+                      onPressed: () => actions.increment(null),
+                      child: Text('Increment'),
                       key: incrementButtonKey,
                     ),
-                    new RaisedButton(
-                      onPressed: actions.incrementOther,
-                      child: new Text('Increment Other'),
+                    ElevatedButton(
+                      onPressed: () => actions.incrementOther(null),
+                      child: Text('Increment Other'),
                       key: incrementOtherButtonKey,
                     ),
-                    new Text(
+                    Text(
                       'Count: $count',
                       key: incrementTextKey,
                     ),
@@ -69,7 +69,7 @@ class ProviderWidgetConnection extends StatelessWidget {
 }
 
 // ignore: must_be_immutable
-class CounterWidget extends StoreConnector<Counter, CounterActions, int> {
+class CounterWidget extends StoreConnector<Counter, CounterActions, int?> {
   // the number of times this component has been rebuild
   // used to test that we don't update after updating state
   // the connect function does not consume
@@ -78,27 +78,27 @@ class CounterWidget extends StoreConnector<Counter, CounterActions, int> {
   CounterWidget() : super(key: counterKey);
 
   @override
-  int connect(Counter state) {
+  int? connect(Counter state) {
     return state.count;
   }
 
   @override
-  Widget build(BuildContext context, int count, CounterActions actions) {
+  Widget build(BuildContext context, int? count, CounterActions actions) {
     numBuilds++;
-    return new Scaffold(
-      body: new Row(
+    return Scaffold(
+      body: Row(
         children: <Widget>[
-          new RaisedButton(
-            onPressed: actions.increment,
-            child: new Text('Increment'),
+          ElevatedButton(
+            onPressed: () => actions.increment(null),
+            child: Text('Increment'),
             key: incrementButtonKey,
           ),
-          new RaisedButton(
-            onPressed: actions.incrementOther,
-            child: new Text('Increment Other'),
+          ElevatedButton(
+            onPressed: () => actions.incrementOther(null),
+            child: Text('Increment Other'),
             key: incrementOtherButtonKey,
           ),
-          new Text(
+          Text(
             'Count: $count',
             key: incrementTextKey,
           ),


### PR DESCRIPTION
- Upgrade to NNBD
- Replace deprecated method BuildContext.inheritFromWidgetOfExactType
- Replace deprecated `RaisedButton` with `ElevatedButton` in example